### PR TITLE
Add notice about isolcpus

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -28,6 +28,15 @@ pub(crate) fn linux_has_module_loaded(name: &str) -> bool {
     reader.lines().any(|line| line.unwrap().contains(name))
 }
 
+pub(crate) fn linux_has_isol_cpu(cpu: usize) -> bool {
+    let file = match File::open("/sys/devices/system/cpu/isolated") {
+        Ok(file) => file,
+        Err(_) => return false,
+    };
+    let reader = BufReader::new(file);
+    reader.lines().any(|line| line.unwrap().contains(&cpu.to_string()))
+}
+
 pub fn set_thread_affinity(core_id: usize) -> bool {
     let mut set: cpu_set_t = unsafe { std::mem::zeroed() };
     unsafe { CPU_SET(core_id, &mut set) }


### PR DESCRIPTION
Setting isolcpu yields a slight peformance improvement. Currently the [rpi-rgb-led-matrix](https://github.com/hzeller/rpi-rgb-led-matrix) shows a message when not setup so I figured the Rust implementation should also.

I also removed the hardcode value of `cpu3` from `cpufreq`. Previously the `set_thread_affinity` was being called on the last core but `cpufreq` had the hardcoded value of `cpu3`. I know that currently raspberry-pis only have either 1 or 4 cores but if there ever is a new pi released with 2 or 6+ cores then the code will always work regardless.

Thanks and awesome crate!