### PR TITLE
Add PixelMapper trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ mod hardware_mapping;
 mod init_sequence;
 mod multiplex_mapper;
 mod pin_pulser;
+mod pixel_mapper;
 mod registers;
 mod rgb_matrix;
 mod row_address_setter;

--- a/src/pixel_mapper.rs
+++ b/src/pixel_mapper.rs
@@ -1,5 +1,9 @@
 use crate::multiplex_mapper::MultiplexMapper;
 
+/// A pixel mapper is a way for you to map pixels of LED matrixes to a different
+/// layout. If you have an implementation of a PixelMapper, you can give it
+/// to the RGBMatrix::apply_pixel_mapper(), which then presents you with a canvas
+/// that has the new "visible width" and "visible height".
 pub(crate) trait PixelMapper {
     /// Given a underlying matrix (width, height), returns the
     /// visible (width, height) after the mapping.

--- a/src/pixel_mapper.rs
+++ b/src/pixel_mapper.rs
@@ -1,0 +1,39 @@
+use crate::multiplex_mapper::MultiplexMapper;
+
+pub(crate) trait PixelMapper {
+    /// Given a underlying matrix (width, height), returns the
+    /// visible (width, height) after the mapping.
+    /// E.g. a 90 degree rotation might map matrix=(64, 32) -> visible=(32, 64)
+    /// Some multiplexing matrices will double the height and half the width.
+    fn get_size_mapping(&self, matrix_width: usize, matrix_height: usize) -> [usize; 2];
+
+    /// Map where a visible pixel (x,y) is mapped to the underlying matrix (x,y).
+    fn map_visible_to_matrix(
+        &self,
+        matrix_width: usize,
+        matrix_height: usize,
+        visible_x: usize,
+        visible_y: usize,
+    ) -> [usize; 2];
+}
+
+pub(crate) struct MultiplexMapperWrapper(pub(crate) Box<dyn MultiplexMapper>);
+
+impl PixelMapper for MultiplexMapperWrapper {
+    fn get_size_mapping(&self, matrix_width: usize, matrix_height: usize) -> [usize; 2] {
+        // Delegate the call to the underlying MultiplexMapper
+        self.0.get_size_mapping(matrix_width, matrix_height)
+    }
+
+    fn map_visible_to_matrix(
+        &self,
+        matrix_width: usize,
+        matrix_height: usize,
+        visible_x: usize,
+        visible_y: usize,
+    ) -> [usize; 2] {
+        // Delegate the call to the underlying MultiplexMapper
+        self.0
+            .map_visible_to_matrix(matrix_width, matrix_height, visible_x, visible_y)
+    }
+}

--- a/src/rgb_matrix.rs
+++ b/src/rgb_matrix.rs
@@ -16,7 +16,7 @@ use crate::{
     canvas::{Canvas, PixelDesignator, PixelDesignatorMap},
     chip::PiChip,
     gpio::{Gpio, GpioInitializationError},
-    multiplex_mapper::MultiplexMapper,
+    pixel_mapper::{MultiplexMapperWrapper, PixelMapper},
     utils::{linux_has_isol_cpu, set_thread_affinity, FrameRateMonitor},
     RGBMatrixConfig,
 };
@@ -148,6 +148,7 @@ impl RGBMatrix {
         if let Some(mapper_type) = config.multiplexing.as_ref() {
             let mut mapper = mapper_type.create();
             mapper.edit_rows_cols(&mut config.rows, &mut config.cols);
+            let mapper = Box::new(MultiplexMapperWrapper(mapper));
             shared_mapper =
                 Self::apply_pixel_mapper(shared_mapper, mapper, &mut config, pixel_designator);
         }
@@ -291,7 +292,7 @@ impl RGBMatrix {
 
     fn apply_pixel_mapper(
         shared_mapper: PixelDesignatorMap,
-        mapper: Box<dyn MultiplexMapper>,
+        mapper: Box<dyn PixelMapper>,
         config: &mut RGBMatrixConfig,
         pixel_designator: PixelDesignator,
     ) -> PixelDesignatorMap {


### PR DESCRIPTION
This PR adds a trait called `PixelMapper` along with its implementations and wrapper struct to enhance the extensibility and organization of the pixel mapping functionality.

- Added a `PixelMapper` trait that defines methods for mapping pixels between an underlying matrix and a visible layout.
- Implemented the `PixelMapper` trait for `MultiplexMapperWrapper` struct. This allows seamless delegation of mapping operations to the underlying `MultiplexMapper`.

We can now pass any `PixelMapper` to `apply_pixel_mapper`. When we are ready to add additional pixel mappers (U-mapper, Rotate, etc), we create another wrapper and implement `PixelMapper` trait for it.