### PR TITLE
Add Rotate and Mirror Mapper

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,8 @@ use argh::FromArgs;
 
 use crate::{
     canvas::LedSequence, init_sequence::PanelType, multiplex_mapper::MultiplexMapperType,
-    row_address_setter::RowAddressSetterType, HardwareMapping, PiChip,
+    named_pixel_mapper::NamedPixelMapperType, row_address_setter::RowAddressSetterType,
+    HardwareMapping, PiChip,
 };
 
 /// Typically, a Hub75 panel is split in two half displays, so that a 1:16 multiplexing actually multiplexes
@@ -79,6 +80,9 @@ pub struct RGBMatrixConfig {
     /// the kind of multiplexing mapper.
     #[argh(option)]
     pub multiplexing: Option<MultiplexMapperType>,
+    /// the kind of pixel mapper.
+    #[argh(option)]
+    pub pixelmapper: Vec<NamedPixelMapperType>,
     /// the row address setter.
     #[argh(option, default = "RowAddressSetterType::Direct")]
     pub row_setter: RowAddressSetterType,
@@ -110,6 +114,7 @@ impl Default for RGBMatrixConfig {
             parallel: 1,
             panel_type: None,
             multiplexing: None,
+            pixelmapper: vec![],
             row_setter: RowAddressSetterType::Direct,
             led_sequence: LedSequence::Rgb,
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ mod gpio;
 mod hardware_mapping;
 mod init_sequence;
 mod multiplex_mapper;
+mod named_pixel_mapper;
 mod pin_pulser;
 mod pixel_mapper;
 mod registers;

--- a/src/named_pixel_mapper.rs
+++ b/src/named_pixel_mapper.rs
@@ -1,8 +1,22 @@
 use std::{error::Error, str::FromStr};
 
+/// Enum representing different pixel mapping options for mapping the logical layout of your boards
+/// to your physical arrangement. These options allow you to customize the mapping to match your unique setup.
+///
+/// These options can be used with the `--pixelmapper` flag to choose between different mappings.
+///
+/// You can apply multiple mappers in your configuration, and they will be applied in the order you specify.
+/// For example, to first mirror the panels horizontally and then rotate the resulting screen,
+/// You can use `--pixelmapper Mirror:H --pixelmapper Rotate:90`
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum NamedPixelMapperType {
+    /// The "Mirror" mapper allows you to mirror the output either horizontally or vertically.
+    /// Specify 'H' for horizontal mirroring or 'V' for vertical mirroring as a parameter after a colon.
+    /// Example: `--pixelmapper Mirror:H`
     Mirror(bool),
+    /// The "Rotate" mapper allows you to rotate your screen by a specified angle in degrees.
+    /// Specify the desired angle as a parameter after a colon.
+    /// Example: `--pixelmapper Rotate:90` for a 90-degree rotation.
     Rotate(usize),
 }
 

--- a/src/named_pixel_mapper.rs
+++ b/src/named_pixel_mapper.rs
@@ -1,0 +1,122 @@
+use std::{error::Error, str::FromStr};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NamedPixelMapperType {
+    Mirror(bool),
+    Rotate(usize),
+}
+
+impl FromStr for NamedPixelMapperType {
+    type Err = Box<dyn Error>;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split(':').collect();
+
+        match parts[0] {
+            "Mirror" => match parts.get(1).map(|&param| param) {
+                Some("H") | Some("h") => Ok(Self::Mirror(true)),
+                Some("V") | Some("v") => Ok(Self::Mirror(false)),
+                Some(other) => Err(format!(
+                    "'{}' is not valid. Mirror parameter should be either 'V' or 'H'",
+                    other
+                )
+                .into()),
+                None => Err("Mirror parameter is missing".into()),
+            },
+            "Rotate" => {
+                match parts
+                    .get(1)
+                    .and_then(|angle_str| angle_str.parse::<usize>().ok())
+                {
+                    Some(angle) if angle % 90 != 0 => Err(format!(
+                        "'{}' is not valid. Rotation needs to be a multiple of 90 degrees",
+                        angle
+                    )
+                    .into()),
+                    Some(angle) => Ok(Self::Rotate((angle + 360) % 360)),
+                    None => Err("Rotation angle is missing or invalid".into()),
+                }
+            }
+            other => Err(format!("'{}' is not a valid Pixel mapping.", other).into()),
+        }
+    }
+}
+
+impl NamedPixelMapperType {
+    pub(crate) fn create(self) -> Box<dyn NamedPixelMapper> {
+        match self {
+            NamedPixelMapperType::Mirror(horizontal) => Box::new(MirrorPixelMapper { horizontal }),
+            NamedPixelMapperType::Rotate(angle) => Box::new(RotatePixelMapper { angle }),
+        }
+    }
+}
+
+/// A pixel mapper is a way for you to map pixels of LED matrixes to a different
+/// layout. If you have an implementation of a PixelMapper, you can give it
+/// to the RGBMatrix::apply_pixel_mapper(), which then presents you a canvas
+/// that has the new "visible_width", "visible_height".
+pub(crate) trait NamedPixelMapper {
+    fn get_size_mapping(&self, matrix_width: usize, matrix_height: usize) -> [usize; 2];
+
+    fn map_visible_to_matrix(
+        &self,
+        matrix_width: usize,
+        matrix_height: usize,
+        visible_x: usize,
+        visible_y: usize,
+    ) -> [usize; 2];
+}
+
+struct MirrorPixelMapper {
+    horizontal: bool,
+}
+
+impl NamedPixelMapper for MirrorPixelMapper {
+    fn get_size_mapping(&self, matrix_width: usize, matrix_height: usize) -> [usize; 2] {
+        [matrix_width, matrix_height]
+    }
+
+    fn map_visible_to_matrix(
+        &self,
+        matrix_width: usize,
+        matrix_height: usize,
+        x: usize,
+        y: usize,
+    ) -> [usize; 2] {
+        if self.horizontal {
+            [matrix_width - 1 - x, y]
+        } else {
+            [x, matrix_height - 1 - y]
+        }
+    }
+}
+
+struct RotatePixelMapper {
+    angle: usize,
+}
+
+impl NamedPixelMapper for RotatePixelMapper {
+    fn get_size_mapping(&self, matrix_width: usize, matrix_height: usize) -> [usize; 2] {
+        if self.angle % 180 == 0 {
+            [matrix_width, matrix_height]
+        } else {
+            [matrix_height, matrix_width]
+        }
+    }
+
+    fn map_visible_to_matrix(
+        &self,
+        matrix_width: usize,
+        matrix_height: usize,
+        x: usize,
+        y: usize,
+    ) -> [usize; 2] {
+        match self.angle {
+            0 => [x, y],
+            90 => [matrix_width - y - 1, x],
+            180 => [matrix_width - x - 1, matrix_height - y - 1],
+            270 => [y, matrix_height - x - 1],
+            _ => unreachable!(),
+        }
+    }
+}

--- a/src/pixel_mapper.rs
+++ b/src/pixel_mapper.rs
@@ -1,4 +1,4 @@
-use crate::multiplex_mapper::MultiplexMapper;
+use crate::{multiplex_mapper::MultiplexMapper, named_pixel_mapper::NamedPixelMapper};
 
 /// A pixel mapper is a way for you to map pixels of LED matrixes to a different
 /// layout. If you have an implementation of a PixelMapper, you can give it
@@ -39,5 +39,25 @@ impl PixelMapper for MultiplexMapperWrapper {
         // Delegate the call to the underlying MultiplexMapper
         self.0
             .map_visible_to_matrix(matrix_width, matrix_height, visible_x, visible_y)
+    }
+}
+
+pub(crate) struct NamedPixelMapperWrapper(pub(crate) Box<dyn NamedPixelMapper>);
+
+impl PixelMapper for NamedPixelMapperWrapper {
+    fn get_size_mapping(&self, width: usize, height: usize) -> [usize; 2] {
+        // Delegate the call to the underlying NamedPixelMapper
+        self.0.get_size_mapping(width, height)
+    }
+
+    fn map_visible_to_matrix(
+        &self,
+        old_width: usize,
+        old_height: usize,
+        x: usize,
+        y: usize,
+    ) -> [usize; 2] {
+        // Delegate the call to the underlying NamedPixelMapper
+        self.0.map_visible_to_matrix(old_width, old_height, x, y)
     }
 }


### PR DESCRIPTION
This PR adds support for Rotate and Mirror mappers.

- Added a `NamedPixelMapper` trait that defines methods for mapping pixels between an underlying matrix and a visible layout.
- Implemented `NamedPixelMapper` for `RotatePixelMapper` and `MirrorPixelMapper`.
- Implemented the `PixelMapper` trait for `NamedPixelMapperWrapper`. 
- Added a new configuration option named `pixelmapper`
- Changed `RGBMatrix::apply_pixel_mapper` function signature.

The name `NamedPixelMapper` came from [the cpp library](https://github.com/hzeller/rpi-rgb-led-matrix/blob/a3eea997a9254b83ab2de97ae80d83588f696387/lib/led-matrix.cc#L389C16-L389C16). It calls `ApplyNamedPixelMappers` to apply these mappers. If you have a better idea, please let me know.
