### PR TITLE
Add U mapper

### DIFF
--- a/src/named_pixel_mapper.rs
+++ b/src/named_pixel_mapper.rs
@@ -18,6 +18,31 @@ pub enum NamedPixelMapperType {
     /// Specify the desired angle as a parameter after a colon.
     /// Example: `--pixelmapper Rotate:90` for a 90-degree rotation.
     Rotate(usize),
+    /// The `UMapper` represents a pixel mapping strategy where a long chain of display panels
+    /// is arranged in a U-shape configuration. This arrangement allows for a single chain display
+    /// with panels of double height but still utilizing only one data chain.
+    ///
+    /// In this U-shape configuration, the panels are bent around after half of them to continue below,
+    /// creating a visually unified display. This arrangement is ideal for scenarios where you want to maximize
+    /// the display area without increasing the number of data chains.
+    ///
+    /// `UMapper` takes no parameters.
+    /// `--pixelmapping U-mapper`
+    ///
+    /// For example, a single chain display with four 32x32 panels like this:
+    ///    [<][<][<][<] }- Raspberry Pi connector
+    ///
+    /// can be arranged in this 64x64 U-shaped display:
+    ///    [<][<] }----- Raspberry Pi connector
+    ///    [>][>]
+    ///
+    /// This U-shape configuration can also be applied to displays with multiple chains.
+    /// For instance, an arrangement with two chains, each consisting of 8 panels, can be represented as follows:
+    ///   [<][<][<][<]  }--- Pi connector #1
+    ///   [>][>][>][>]
+    ///   [<][<][<][<]  }--- Pi connector #2
+    ///   [>][>][>][>]
+    UMapper,
 }
 
 impl FromStr for NamedPixelMapperType {
@@ -50,17 +75,22 @@ impl FromStr for NamedPixelMapperType {
                 }
                 other => Err(format!("'{}' is not a valid Pixel mapping.", other).into()),
             }
+        } else if s == "U-mapper" {
+            Ok(Self::UMapper)
         } else {
-            Err("Invalid format: no ':' separator found.".into())
+            Err(format!("'{}' is not a valid Pixel mapping.", s).into())
         }
     }
 }
 
 impl NamedPixelMapperType {
-    pub(crate) fn create(self) -> Box<dyn NamedPixelMapper> {
+    pub(crate) fn create(self, chain: usize, parallel: usize) -> Box<dyn NamedPixelMapper> {
         match self {
             NamedPixelMapperType::Mirror(horizontal) => Box::new(MirrorPixelMapper { horizontal }),
             NamedPixelMapperType::Rotate(angle) => Box::new(RotatePixelMapper { angle }),
+            NamedPixelMapperType::UMapper => {
+                Box::new(UArrangeMapper::new_with_parameters(chain, parallel))
+            }
         }
     }
 }
@@ -132,5 +162,61 @@ impl NamedPixelMapper for RotatePixelMapper {
             270 => [y, matrix_height - x - 1],
             _ => unreachable!(),
         }
+    }
+}
+
+struct UArrangeMapper {
+    parallel: usize,
+}
+
+impl UArrangeMapper {
+    fn new_with_parameters(chain: usize, parallel: usize) -> Self {
+        if chain < 2 {
+            // technically, a chain of 2 would work, but somewhat pointless
+            panic!("U-mapper: need at least '--chain_length 4' for useful folding");
+        }
+        if chain % 2 != 0 {
+            panic!("U-mapper: Chain (--chain_length) needs to be divisible by two");
+        }
+        Self { parallel }
+    }
+}
+
+impl NamedPixelMapper for UArrangeMapper {
+    fn get_size_mapping(&self, matrix_width: usize, matrix_height: usize) -> [usize; 2] {
+        let visible_width = (matrix_width / 64) * 32; // Div at 32px boundary
+        let visible_height = 2 * matrix_height;
+        if matrix_height % self.parallel != 0 {
+            eprintln!(
+                "For parallel={} we would expect the height={matrix_height} to be divisible by {}.",
+                self.parallel, self.parallel
+            );
+        }
+        [visible_width, visible_height]
+    }
+
+    fn map_visible_to_matrix(
+        &self,
+        matrix_width: usize,
+        matrix_height: usize,
+        x: usize,
+        y: usize,
+    ) -> [usize; 2] {
+        let panel_height = matrix_height / self.parallel;
+        let visible_width = (matrix_width / 64) * 32;
+        let slab_height = 2 * panel_height; // one folded u-shape
+        let base_y = (y / slab_height) * panel_height;
+
+        let mut matrix_x = x;
+        let mut matrix_y = y % slab_height;
+
+        if matrix_y < panel_height {
+            matrix_x += matrix_width / 2;
+        } else {
+            matrix_x = visible_width - x - 1;
+            matrix_y = slab_height - y - 1;
+        }
+
+        [matrix_x, base_y + matrix_y]
     }
 }

--- a/src/rgb_matrix.rs
+++ b/src/rgb_matrix.rs
@@ -159,7 +159,8 @@ impl RGBMatrix {
         // Apply higher level mappers that might arrange panels.
         let pixelmappers = config.pixelmapper.clone();
         for mapper_type in pixelmappers {
-            let mapper: NamedPixelMapperWrapper = NamedPixelMapperWrapper(mapper_type.create());
+            let mapper: NamedPixelMapperWrapper =
+                NamedPixelMapperWrapper(mapper_type.create(config.chain_length, config.parallel));
             shared_mapper =
                 Self::apply_pixel_mapper(shared_mapper, mapper, &config, pixel_designator);
         }


### PR DESCRIPTION
- Added the implementation for the U Mapper.
- Modified `NamedPixelMapperType::create` to accept `chain` and `parallel` parameters, enabling proper configuration for U (and V) mapping.