### PR TITLE
Actually make use of the `slowdown` config option

### DIFF
--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -131,7 +131,7 @@ impl Gpio {
             &mut clk_registers,
         );
 
-        let gpio_slowdown = chip.gpio_slowdown();
+        let gpio_slowdown = config.slowdown.unwrap_or_else(|| chip.gpio_slowdown());
 
         Ok(Self {
             gpio_registers,


### PR DESCRIPTION
The `RGBMatrixConfig::slowdown` option is not currently being used to actually set the gpio_slowdown, which was causing issues for me on a RPi 4 (which required a slowdown of 3).

This tiny change will make it so that the `slowdown` option in the `RGBMatrixConfig` will be used in place of `chip.gpio_slowdown()`, unless it is set to None (which is the default).