### PR TITLE
Fix Logic Error in UArrangeMapper's map_visible_to_matrix Function for parallel Configurations

### DIFF
--- a/src/named_pixel_mapper.rs
+++ b/src/named_pixel_mapper.rs
@@ -206,16 +206,15 @@ impl NamedPixelMapper for UArrangeMapper {
         let visible_width = (matrix_width / 64) * 32;
         let slab_height = 2 * panel_height; // one folded u-shape
         let base_y = (y / slab_height) * panel_height;
+        let y_in_slab = y % slab_height;
 
-        let mut matrix_x = x;
-        let mut matrix_y = y % slab_height;
-
-        if matrix_y < panel_height {
-            matrix_x += matrix_width / 2;
+        let [matrix_x, matrix_y] = if y_in_slab < panel_height {
+            // Upper panel of the slab
+            [(x + matrix_width / 2), y_in_slab]
         } else {
-            matrix_x = visible_width - x - 1;
-            matrix_y = slab_height - y - 1;
-        }
+            // Lower panel of the slab
+            [(visible_width - x - 1), (slab_height - y_in_slab - 1)]
+        };
 
         [matrix_x, base_y + matrix_y]
     }


### PR DESCRIPTION
**Description:**
This pull request addresses a logic error in the `map_visible_to_matrix` function within the `UArrangeMapper` implementation. The issue arises when the `parallel` configuration is set to a value greater than `1`.

**Before:**
In the original code, the logic worked correctly when the `parallel` configuration was set to `1`, as in this case, `y` and `matrix_y` coincidentally held the same value. However, when `parallel` was set to `2` or a larger number, a discrepancy emerged, leading to errors.

**After:**
The updated code fixes the logic error and correctly calculates the value. This adjustment ensures correct behavior across different configurations of the `parallel` setting.

This fix has been tested and verified.
Additionally, variable names and comments have been updated to enhance clarity and maintainability.
