### PR TITLE
Add `led_brightness` option to `RGBMatrixConfig`

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -192,7 +192,7 @@ impl Canvas {
             bitplane_buffer: vec![0u32; double_rows * cols * K_BIT_PLANES],
             shared_mapper,
             pwm_bits: config.pwm_bits,
-            brightness: 100,
+            brightness: config.led_brightness.clamp(1, 100),
             color_lookup,
             interlaced: config.interlaced,
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,6 +89,9 @@ pub struct RGBMatrixConfig {
     /// the LED sequence, Default: "RGB"
     #[argh(option, default = "LedSequence::Rgb")]
     pub led_sequence: LedSequence,
+    /// brightness in percent. Default: 100
+    #[argh(option, default = "100")]
+    pub led_brightness: u8,
 }
 
 impl RGBMatrixConfig {
@@ -117,6 +120,7 @@ impl Default for RGBMatrixConfig {
             pixelmapper: vec![],
             row_setter: RowAddressSetterType::Direct,
             led_sequence: LedSequence::Rgb,
+            led_brightness: 100,
         }
     }
 }


### PR DESCRIPTION
This pull request adds a new configuration option `led_brightness` to the `RGBMatrixConfig` struct in order to control the brightness of the LED display. This option allows users to specify the brightness level as a percentage.

- Added a new field `led_brightness` of type `u8` to the `RGBMatrixConfig` struct.
- The `led_brightness` field is included in the default implementation of `RGBMatrixConfig`, with a default value of 100 (i.e., full brightness).
- The `led_brightness` field is clamped to ensure that the specified brightness level is within the valid range of 1 to 100.