### PR TITLE
make NamedPixelMapperType public so it can be used in the configuration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,3 +22,4 @@ pub use init_sequence::PanelType;
 pub use multiplex_mapper::MultiplexMapperType;
 pub use rgb_matrix::RGBMatrix;
 pub use row_address_setter::RowAddressSetterType;
+pub use named_pixel_mapper::NamedPixelMapperType;


### PR DESCRIPTION
The `RGBMatrixConfig` struct has the option to pass in a vector of NamedPixelMapperType but this is currently private and can't be used. This fixes that.