### PR TITLE
Support privilege dropping after initialization using privdrop.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "embedded-graphics"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,12 +135,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c8dda44ff03a2f238717214da50f65d5a53b45cd213a7370424ffdb6fae815"
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "privdrop"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70722a5a3728c9603c8d9469b64b8d1ee54dae6d74e24146da7f501b4c76540f"
+dependencies = [
+ "libc",
+ "nix",
 ]
 
 [[package]]
@@ -163,6 +191,7 @@ dependencies = [
  "embedded-graphics",
  "libc",
  "memmap2",
+ "privdrop",
  "strum",
  "thread-priority",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,3 +32,4 @@ embedded-graphics = { version = "0.8.2", optional = true }
 thread-priority = "3.0.0"
 libc = "0.2.184"
 strum = { version = "0.28.0", features = ["derive"] }
+privdrop = "0.5.6"

--- a/src/config.rs
+++ b/src/config.rs
@@ -92,6 +92,15 @@ pub struct RGBMatrixConfig {
     /// brightness in percent. Default: 100
     #[argh(option, default = "100")]
     pub led_brightness: u8,
+    /// drop privileges from root after initialization. Default: true
+    #[argh(option, default = "true")]
+    pub drop_privs: bool,
+    /// username or UID to drop privileges to. Default: daemon
+    #[argh(option, default = "String::from(\"daemon\")")]
+    pub drop_priv_user: String,
+    /// group name or GID to drop privileges to. Default: daemon
+    #[argh(option, default = "String::from(\"daemon\")")]
+    pub drop_priv_group: String,
 }
 
 impl RGBMatrixConfig {
@@ -121,6 +130,9 @@ impl Default for RGBMatrixConfig {
             row_setter: RowAddressSetterType::Direct,
             led_sequence: LedSequence::Rgb,
             led_brightness: 100,
+            drop_privs: true,
+            drop_priv_user: String::from("daemon"),
+            drop_priv_group: String::from("daemon"),
         }
     }
 }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -66,6 +66,7 @@ pub(crate) struct Gpio {
 
 impl Gpio {
     /// Initialize GPIO and loads all registers. Needs root privileges.
+    /// Will result in the application dropping those privileges if privilege dropping is enabled in the config.
     pub(crate) fn new(
         chip: PiChip,
         config: &RGBMatrixConfig,

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -3,6 +3,8 @@ use std::{
     fmt::{Display, Formatter},
 };
 
+use privdrop::{PrivDrop, PrivDropError};
+
 use crate::{
     RGBMatrixConfig,
     chip::PiChip,
@@ -18,6 +20,7 @@ use crate::{
 pub enum GpioInitializationError {
     OneWireProtocolEnabled,
     SoundModuleLoaded,
+    FailedPrivilegeDrop(PrivDropError),
 }
 
 impl Error for GpioInitializationError {}
@@ -37,7 +40,16 @@ impl Display for GpioInitializationError {
                 `/etc/modprobe.d/alsa-blacklist.conf`\n\
                 Finally, reboot the system and try again.",
             ),
+            GpioInitializationError::FailedPrivilegeDrop(e) => {
+                f.write_str(&format!("Failed to drop privileges. Reason: {}", e))
+            }
         }
+    }
+}
+
+impl From<PrivDropError> for GpioInitializationError {
+    fn from(e: PrivDropError) -> Self {
+        GpioInitializationError::FailedPrivilegeDrop(e)
     }
 }
 
@@ -67,7 +79,15 @@ impl Gpio {
         let time_registers = TimeRegisters::new(chip);
         let mut pwm_registers = PWMRegisters::new(chip);
         let mut clk_registers = ClkRegisters::new(chip);
-        // TODO: We can drop privileges here.
+
+        // Drop privileges here as we no longer need root.
+        if config.drop_privs {
+            PrivDrop::default()
+                .user(&config.drop_priv_user)
+                .group(&config.drop_priv_group)
+                .fallback_to_ids_if_names_are_numeric()
+                .apply()?;
+        }
 
         // Tell GPIO about all bits we intend to use.
         let mut all_used_bits: u32 = 0;

--- a/src/rgb_matrix.rs
+++ b/src/rgb_matrix.rs
@@ -125,6 +125,9 @@ impl RGBMatrix {
     /// [`RGBMatrix::receive_new_inputs`]. Only bits that are not already in use for reading or writing by the
     /// matrix are allowed. Use [`RGBMatrix::enabled_input_bits`] after calling this function to check which
     /// bits were actually available.
+    ///
+    /// Note: If privilege dropping is enabled in the config, then calling this function will have the side
+    /// effect of dropping the application's privileges down to the configured user/group.
     pub fn new(
         mut config: RGBMatrixConfig,
         requested_inputs: u32,


### PR DESCRIPTION
Like the original C++ repo, the application now drops to "daemon" user/group by default once root permission is no longer needed.

Adds dependency on https://crates.io/crates/privdrop to perform the privilege dropping.

This is my first ever Rust PR, so please provide feedback on anything that could be done better.