### PR TITLE
Fix framerate monitor

### DIFF
--- a/src/rgb_matrix.rs
+++ b/src/rgb_matrix.rs
@@ -3,12 +3,12 @@ use std::{
     fmt::{Display, Formatter},
     fs::{OpenOptions, write},
     mem::replace,
+    sync::Arc,
+    sync::atomic::{AtomicU32, Ordering},
     sync::mpsc::{Receiver, Sender, SyncSender, TryRecvError, channel, sync_channel},
     thread::{JoinHandle, spawn},
     time::Duration,
 };
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
 use thread_priority::{ThreadPriority, set_current_thread_priority};
 
 use crate::{
@@ -295,7 +295,7 @@ impl RGBMatrix {
                 color_clk_mask,
             );
         });
-        
+
         let enabled_input_bits = thread_start_result_receiver
             .recv_timeout(Duration::from_secs(10))
             .map_err(|_| MatrixCreationError::ThreadTimedOut)??;

--- a/src/rgb_matrix.rs
+++ b/src/rgb_matrix.rs
@@ -379,7 +379,7 @@ impl RGBMatrix {
     /// Get the average frame rate over the last 60 frames.
     #[must_use]
     pub fn get_framerate(&self) -> usize {
-        f32::from_bits(self.framerate.load(Ordering::Relaxed)) as usize
+        self.framerate.load(Ordering::Relaxed) as usize
     }
 }
 

--- a/src/rgb_matrix.rs
+++ b/src/rgb_matrix.rs
@@ -7,7 +7,8 @@ use std::{
     thread::{JoinHandle, spawn},
     time::Duration,
 };
-
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 use thread_priority::{ThreadPriority, set_current_thread_priority};
 
 use crate::{
@@ -112,7 +113,7 @@ pub struct RGBMatrix {
     /// Additional requested inputs that can be received.
     enabled_input_bits: u32,
     /// Frame rate measurement.
-    frame_rate_monitor: FrameRateMonitor,
+    framerate: Arc<AtomicU32>,
 }
 
 impl RGBMatrix {
@@ -195,6 +196,8 @@ impl RGBMatrix {
         let (input_sender, input_receiver) = channel::<u32>();
         let (thread_start_result_sender, thread_start_result_receiver) =
             channel::<Result<u32, MatrixCreationError>>();
+        let framerate = Arc::new(AtomicU32::new(0));
+        let mut frame_rate_monitor = FrameRateMonitor::new(framerate.clone());
 
         let thread_handle = spawn(move || {
             initialize_update_thread(chip);
@@ -272,6 +275,8 @@ impl RGBMatrix {
                 );
                 dither_low_bit_sequence += 1;
 
+                frame_rate_monitor.update();
+
                 // Sleep for the rest of the frame.
                 let now_time = gpio.get_time();
                 let end_time = start_time + frame_time_target_us;
@@ -290,7 +295,7 @@ impl RGBMatrix {
                 color_clk_mask,
             );
         });
-
+        
         let enabled_input_bits = thread_start_result_receiver
             .recv_timeout(Duration::from_secs(10))
             .map_err(|_| MatrixCreationError::ThreadTimedOut)??;
@@ -302,7 +307,7 @@ impl RGBMatrix {
             canvas_to_thread_sender,
             canvas_from_thread_receiver,
             enabled_input_bits,
-            frame_rate_monitor: FrameRateMonitor::new(),
+            framerate,
         };
 
         Ok((rgbmatrix, canvas))
@@ -342,15 +347,12 @@ impl RGBMatrix {
         let Self {
             canvas_to_thread_sender,
             canvas_from_thread_receiver,
-            frame_rate_monitor,
             ..
         } = self;
 
         canvas_to_thread_sender
             .send(canvas)
             .expect("Display update thread shut down unexpectedly.");
-
-        frame_rate_monitor.update();
 
         let mut canvas = canvas_from_thread_receiver
             .recv()
@@ -377,7 +379,7 @@ impl RGBMatrix {
     /// Get the average frame rate over the last 60 frames.
     #[must_use]
     pub fn get_framerate(&self) -> usize {
-        self.frame_rate_monitor.get_fps().round() as usize
+        f32::from_bits(self.framerate.load(Ordering::Relaxed)) as usize
     }
 }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -4,7 +4,8 @@ use std::{
     io::{BufRead, BufReader},
     thread, time,
 };
-
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 use libc::{
     CPU_SET, cpu_set_t, getgrnam, getpwnam, gid_t, sched_setaffinity, setgid, setuid, uid_t,
 };
@@ -111,14 +112,16 @@ pub(crate) struct FrameRateMonitor {
     times: [f32; WINDOW_LENGTH],
     index: usize,
     last_time: Option<time::Instant>,
+    framerate: Arc<AtomicU32>,
 }
 
 impl FrameRateMonitor {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new(framerate: Arc<AtomicU32>) -> Self {
         Self {
             times: [1.0 / WINDOW_LENGTH as f32; WINDOW_LENGTH],
             index: 0,
             last_time: None,
+            framerate,
         }
     }
 
@@ -128,6 +131,8 @@ impl FrameRateMonitor {
             self.index = (self.index + 1) % WINDOW_LENGTH;
         }
         self.last_time = Some(time::Instant::now());
+
+        self.framerate.store(self.get_fps().to_bits(), Ordering::Relaxed);
     }
 
     pub(crate) fn get_fps(&self) -> f32 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,13 +1,13 @@
+use libc::{
+    CPU_SET, cpu_set_t, getgrnam, getpwnam, gid_t, sched_setaffinity, setgid, setuid, uid_t,
+};
 use std::{
     ffi::CString,
     fs::File,
     io::{BufRead, BufReader},
+    sync::Arc,
+    sync::atomic::{AtomicU32, Ordering},
     thread, time,
-};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU32, Ordering};
-use libc::{
-    CPU_SET, cpu_set_t, getgrnam, getpwnam, gid_t, sched_setaffinity, setgid, setuid, uid_t,
 };
 
 /// Sets the bits that are passed as arguments.
@@ -132,7 +132,8 @@ impl FrameRateMonitor {
         }
         self.last_time = Some(time::Instant::now());
 
-        self.framerate.store(self.get_fps().to_bits(), Ordering::Relaxed);
+        self.framerate
+            .store(self.get_fps().to_bits(), Ordering::Relaxed);
     }
 
     pub(crate) fn get_fps(&self) -> f32 {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -133,7 +133,7 @@ impl FrameRateMonitor {
         self.last_time = Some(time::Instant::now());
 
         self.framerate
-            .store(self.get_fps().to_bits(), Ordering::Relaxed);
+            .store(self.get_fps() as u32, Ordering::Relaxed);
     }
 
     pub(crate) fn get_fps(&self) -> f32 {


### PR DESCRIPTION
The framerate monitor is now owned by the frame update thread and updates the framerate each frame. The framerate is stored in an AtomicU32 shared by the frame update thread and the rgb matrix struct so the rgb matrix struct can safely read the framerate.

Threads are not my specialty, so this might not be the best or cleanest solution. I also did not want to change too much about the framerate monitor implementation, but maybe a partial rewrite of that would give a better solution.

Fixes #26 